### PR TITLE
Add stdlib to ZUC.h for malloc

### DIFF
--- a/ZUC.h
+++ b/ZUC.h
@@ -8,6 +8,8 @@
 #	define EXPORTIT
 #endif
 
+#include <stdlib.h>
+
 /*------------------------------------------------------------------------
  * ZUC.h
  * Code taken from the ZUC specification


### PR DESCRIPTION
Won't compile with stdlib since malloc, etc is used in ZUC.c
